### PR TITLE
vcpuosv: Read distro from /etc/os-release

### DIFF
--- a/src/bin/vcpuosv.src
+++ b/src/bin/vcpuosv.src
@@ -57,8 +57,14 @@ linux_get_lscpu_field() {
 if test $OSNAME = "Linux";
 then
 
-    ENDSTRING="\\n \\\l"
-    DISTR=`cat /etc/issue | grep "$ENDSTRING" | sed -e "s/.\{6\}\$//"`
+
+    if [ -f /etc/os-release ]; then
+        # freedesktop.org and systemd
+        DISTR=`awk -F= '$1=="NAME" { print $2 ;}' /etc/os-release | tr -d '"'`
+    else
+        ENDSTRING="\\n \\\l"
+        DISTR=`cat /etc/issue | grep "$ENDSTRING" | sed -e "s/.\{6\}\$//"`
+    fi
     OS="GNU/Linux ($DISTR)"
 
     MODELRAW=`cat /proc/cpuinfo | grep "model name" | uniq | sed -e "s/.*: //"`


### PR DESCRIPTION
/etc/os-release should be supported by most modern Linux distributions.
See: http://0pointer.de/blog/projects/os-release