### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/java/com/verificatum/arithm/BPGroupElementBatchReader.java
+++ b/src/java/com/verificatum/arithm/BPGroupElementBatchReader.java
@@ -81,6 +81,7 @@ public final class BPGroupElementBatchReader {
                 return elements;
             }
         } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
             throw new ArithmError("Failed to read next batch!", ie);
         }
     }
@@ -152,6 +153,7 @@ final class BPGroupElementBatchReaderThread extends Thread {
                 try {
                     Thread.sleep(BPGroupElementBatchReader.BATCH_SLEEP_TIME);
                 } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }

--- a/src/java/com/verificatum/arithm/BPGroupElementBatchWriter.java
+++ b/src/java/com/verificatum/arithm/BPGroupElementBatchWriter.java
@@ -67,6 +67,7 @@ public class BPGroupElementBatchWriter {
             try {
                 Thread.sleep(100);
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
             }
         }
 
@@ -92,6 +93,7 @@ public class BPGroupElementBatchWriter {
             try {
                 Thread.sleep(100);
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
             }
         }
         btw.close();

--- a/src/java/com/verificatum/arithm/LargeIntegerArrayF.java
+++ b/src/java/com/verificatum/arithm/LargeIntegerArrayF.java
@@ -858,6 +858,7 @@ public final class LargeIntegerArrayF extends LargeIntegerArray {
                 try {
                     Thread.sleep(100);
                 } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                 }
             }
 
@@ -884,6 +885,7 @@ public final class LargeIntegerArrayF extends LargeIntegerArray {
                 try {
                     Thread.sleep(100);
                 } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                 }
             }
             btw.close();

--- a/src/java/com/verificatum/arithm/LargeIntegerBatchReader.java
+++ b/src/java/com/verificatum/arithm/LargeIntegerBatchReader.java
@@ -80,6 +80,7 @@ public final class LargeIntegerBatchReader {
                 return integers;
             }
         } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
             throw new ArithmError("Failed to read next batch!", ie);
         }
     }
@@ -142,6 +143,7 @@ final class LargeIntegerBatchReaderThread extends Thread {
                 try {
                     Thread.sleep(LargeIntegerBatchReader.BATCH_SLEEP_TIME);
                 } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }

--- a/src/java/com/verificatum/crypto/PRG.java
+++ b/src/java/com/verificatum/crypto/PRG.java
@@ -166,6 +166,7 @@ public abstract class PRG extends RandomSource {
             try {
                 Thread.sleep(SEED_GRAB_SLEEP);
             } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
             i++;
         }

--- a/src/java/com/verificatum/protocol/Shutdown.java
+++ b/src/java/com/verificatum/protocol/Shutdown.java
@@ -71,6 +71,7 @@ public final class Shutdown extends ProtocolBB {
             Thread.sleep(WAIT_FOR_OTHERS_TIME);
         } catch (final InterruptedException ie) {
             // User requested immediate shutdown. Do nothing.
+            Thread.currentThread().interrupt();
         }
         bullBoard.stop(log);
     }

--- a/src/java/com/verificatum/protocol/com/BullBoardBasicHTTPW.java
+++ b/src/java/com/verificatum/protocol/com/BullBoardBasicHTTPW.java
@@ -232,6 +232,7 @@ public final class BullBoardBasicHTTPW extends BullBoardBasicHTTP {
                 try {
                     sleeper.wait();
                 } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                 }
                 alive = false;
             }

--- a/src/java/com/verificatum/protocol/com/BullBoardBasicSingle.java
+++ b/src/java/com/verificatum/protocol/com/BullBoardBasicSingle.java
@@ -189,6 +189,7 @@ public final class BullBoardBasicSingle extends BullBoardBasic {
             try {
                 Thread.sleep(SLEEP_TIME);
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/src/java/com/verificatum/protocol/com/HintServer.java
+++ b/src/java/com/verificatum/protocol/com/HintServer.java
@@ -119,6 +119,7 @@ public final class HintServer implements Runnable {
                     try {
                         Thread.sleep(SOCKET_ATTEMPT_SLEEP);
                     } catch (final InterruptedException ie) {
+                        Thread.currentThread().interrupt();
                     }
                 }
             }

--- a/src/java/com/verificatum/protocol/com/SimpleHTTPServer.java
+++ b/src/java/com/verificatum/protocol/com/SimpleHTTPServer.java
@@ -184,6 +184,7 @@ public final class SimpleHTTPServer {
                     try {
                         Thread.sleep(SOCKET_ATTEMPT_SLEEP);
                     } catch (final InterruptedException ie) {
+                        Thread.currentThread().interrupt();
                     }
                 }
             }

--- a/src/java/com/verificatum/protocol/com/Sleeper.java
+++ b/src/java/com/verificatum/protocol/com/Sleeper.java
@@ -57,6 +57,7 @@ public final class Sleeper extends Thread {
         try {
             Thread.sleep(waitTime);
         } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/src/java/com/verificatum/tests/crypto/TestPRG.java
+++ b/src/java/com/verificatum/tests/crypto/TestPRG.java
@@ -172,11 +172,13 @@ public abstract class TestPRG extends TestClass {
         try {
             Thread.sleep(500);
         } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
         }
         ExtIO.atomicWriteString(TempFile.getFile(), seedFile, sb.toString());
         try {
             thread.join();
         } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
         }
         if (failed[0] != null) {
             throw new CryptoException(failed[0]);

--- a/src/java/com/verificatum/ui/gui/JConsoleOutLinker.java
+++ b/src/java/com/verificatum/ui/gui/JConsoleOutLinker.java
@@ -100,6 +100,7 @@ public final class JConsoleOutLinker implements Runnable {
                     this.wait(100);
                 }
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
             }
 
             int len = 0;

--- a/src/java/com/verificatum/util/ArrayWorker.java
+++ b/src/java/com/verificatum/util/ArrayWorker.java
@@ -119,6 +119,7 @@ public abstract class ArrayWorker {
             try {
                 executor.invoke(callables);
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
                 throw new UtilError("Interrupted threaded computatation!", ie);
             }
 

--- a/src/java/com/verificatum/util/Command.java
+++ b/src/java/com/verificatum/util/Command.java
@@ -69,6 +69,7 @@ public final class Command {
                 try {
                     process.waitFor();
                 } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                     throw new UtilException("Native call was interrupted!", ie);
                 }
                 return new Pair<Integer, String>(process.exitValue(), output);

--- a/src/java/com/verificatum/util/SplitWorker.java
+++ b/src/java/com/verificatum/util/SplitWorker.java
@@ -121,6 +121,7 @@ public abstract class SplitWorker<T> {
             try {
                 return executor.invoke(callables);
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
                 throw new UtilError("Interrupted threaded computatation!", ie);
             }
 


### PR DESCRIPTION
Hi,

This PR fixes 21 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).